### PR TITLE
PHP 8 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "google/apiclient": "^2.2",
         "kunalvarma05/dropbox-php-sdk": "dev-master",
         "socialiteproviders/dropbox": "^4.0",
-        "socialiteproviders/google": "^3.0",
+        "socialiteproviders/google": "^3.0||^4.0",
         "stechstudio/backoff": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
The Google socialite provider doesn't add support for PHP 8 until version 4. This allows for either version 3 or 4 to be used.